### PR TITLE
fixed OKAPI rootpath

### DIFF
--- a/htdocs/okapi/index.php
+++ b/htdocs/okapi/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$GLOBALS['rootpath'] = __DIR__.'/../vendor/opencaching/';
+$GLOBALS['rootpath'] = __DIR__.'/../';
 
 require_once __DIR__ . '/../vendor/autoload.php';
 


### PR DESCRIPTION
`$GLOBALS['rootpath']` is the OC rootpath, not the Okapi rootpath